### PR TITLE
Cron job at 01:00 not every minute of the first hour

### DIFF
--- a/conf/aeneria.cron
+++ b/conf/aeneria.cron
@@ -1,1 +1,1 @@
-0 1 * * * #USER# php7.3 #DESTDIR#/bin/console aeneria:fetch-data
+*/20 * * * * #USER# php7.3 #DESTDIR#/bin/console aeneria:fetch-data

--- a/conf/aeneria.cron
+++ b/conf/aeneria.cron
@@ -1,1 +1,1 @@
-* 1 * * * #USER# php7.3 #DESTDIR#/bin/console aeneria:fetch-data
+0 1 * * * #USER# php7.3 #DESTDIR#/bin/console aeneria:fetch-data


### PR DESCRIPTION
## Problem
- *`* 1 * * *` means "At every minute past hour 1."*

## Solution
- *Trigger the job at 01am*

You can play with this [website](https://crontab.guru/) for a deeper understanding of cron

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/aeneria_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/aeneria_ynh%20PR-NUM-%20(USERNAME)/)
