### PR TITLE
Fix upgrade after change url

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -46,7 +46,7 @@ ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
 ynh_script_progression --message="Storing installation settings..." --weight=1
 
 ynh_app_setting_set --app=$app --key=domain --value=$domain
-ynh_app_setting_set --app=$app --key=path_url --value=$path_url
+ynh_app_setting_set --app=$app --key=path --value=$path_url
 ynh_app_setting_set --app=$app --key=admin --value=$admin
 ynh_app_setting_set --app=$app --key=is_public --value=$is_public
 ynh_app_setting_set --app=$app --key=deskey --value=$deskey

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,7 +20,7 @@ app=$YNH_APP_INSTANCE_NAME
 ynh_app_setting_set --app=$app --key=phpversion --value=$YNH_PHP_VERSION
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
-path_url=$(ynh_app_setting_get --app=$app --key=path_url)
+path_url=$(ynh_app_setting_get --app=$app --key=path)
 admin=$(ynh_app_setting_get --app=$app --key=admin)
 is_public=$(ynh_app_setting_get --app=$app --key=is_public)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
@@ -41,12 +41,6 @@ upgrade_type=$(ynh_check_app_version_changed)
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..."
-
-# Compatibility with previous version
-if [ -z "$path_url" ] ; then
-  path_url=$(ynh_app_setting_get --app="$app" --key=path)
-  ynh_app_setting_set --app=$app --key=path_url --value="$path_url"
-fi
 
 # If db_name doesn't exist, create it
 if [ -z "$db_name" ]; then


### PR DESCRIPTION
## Problem
- *When I update the application after changing the url of my application, I get the default page "Welcome to nginx!" instead of Aeneria*

## Solution
- *YunoHost uses the keywords `domain` and `path` in helpers and in the core, so use the same*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/aeneria_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/aeneria_ynh%20PR-NUM-%20(USERNAME)/)
